### PR TITLE
fix(ci): make secret rotation approval-only

### DIFF
--- a/.github/workflows/rotate-secrets.yml
+++ b/.github/workflows/rotate-secrets.yml
@@ -1,9 +1,7 @@
 name: Rotate Secrets
 
 on:
-  schedule:
-    # Run weekly on Sunday at 2 AM UTC
-    - cron: '0 2 * * 0'
+  # Secret rotation mutates external providers and therefore runs only by explicit dispatch.
   workflow_dispatch:
     inputs:
       force:
@@ -11,6 +9,10 @@ on:
         required: false
         default: 'false'
         type: boolean
+
+permissions:
+  contents: read
+  issues: write
 
 jobs:
   rotate-secrets:
@@ -51,13 +53,32 @@ jobs:
 
       - name: Notify on failure
         if: failure()
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         with:
           script: |
-            github.rest.issues.create({
+            const title = 'Secrets rotation failed';
+            const body = 'Manual secrets rotation failed. Review the workflow run and rotate through the approved provider path.';
+            const { data: openIssues } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: 'Secrets rotation failed',
-              body: 'Automated secrets rotation failed. Please review and rotate manually.',
-              labels: ['security', 'automation']
-            })
+              state: 'open',
+              labels: 'security,automation',
+              per_page: 100
+            });
+            const existing = openIssues.find(issue => issue.title === title);
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body: `Another manual rotation attempt failed: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['security', 'automation']
+              });
+            }


### PR DESCRIPTION
Removes the scheduled provider-mutation attempt, keeps explicit workflow dispatch, grants only the permissions required for failure reporting, and deduplicates failure issues.